### PR TITLE
preprocessor bugfix

### DIFF
--- a/minifier.py
+++ b/minifier.py
@@ -134,6 +134,7 @@ def fix_unary_operators(lines):
 
 
 def minify_source_file(args, filename):
+    minified_file = ""
     with open(filename) as f:
         if args.names is True:
             print("File {}:".format(source_file))
@@ -166,9 +167,17 @@ def minify_source_file(args, filename):
         # There is no syntactic requirement of an operator being spaced from a '{' in C so
         # if we added unnecessary space when processing spaced ops, we can fix it here
         minified = fix_spaced_ops(minified)
-        print(minified)
+        minified_file += minified
         if args.stats is True:
             show_stats(f, minified)
+    # Add a newline before every hash if neccessary
+    for i, c in enumerate(minified_file):
+        if i >= 1:
+            if c == '#':
+                if minified_file[i-1] != '\n':
+                    minified_file = minified_file[:i] + '\n' + minified_file[i:]
+
+    print(minified_file)
 
 
 def get_args():

--- a/minifier.py
+++ b/minifier.py
@@ -134,7 +134,7 @@ def fix_unary_operators(lines):
 
 
 def minify_source_file(args, filename):
-    minified_file = ""
+    intermediate_string = ""
     with open(filename) as f:
         if args.names is True:
             print("File {}:".format(source_file))
@@ -167,17 +167,22 @@ def minify_source_file(args, filename):
         # There is no syntactic requirement of an operator being spaced from a '{' in C so
         # if we added unnecessary space when processing spaced ops, we can fix it here
         minified = fix_spaced_ops(minified)
-        minified_file += minified
+        intermediate_string += minified
         if args.stats is True:
             show_stats(f, minified)
     # Add a newline before every hash if neccessary
-    for i, c in enumerate(minified_file):
+    for i, c in enumerate(intermediate_string):
         if i >= 1:
             if c == '#':
-                if minified_file[i-1] != '\n':
-                    minified_file = minified_file[:i] + '\n' + minified_file[i:]
+                if intermediate_string[i-1] != '\n':
+                    intermediate_string = intermediate_string[:i] + '\n' + intermediate_string[i:]
+    # Delete empty lines inserted by previous loop
+    for i, c in enumerate(intermediate_string):
+        if i >= 1:
+            if intermediate_string[i] == '\n' and intermediate_string[i+1] == '\n':
+                final_string = intermediate_string[:i] + intermediate_string[i+1:]
 
-    print(minified_file)
+    print(final_string)
 
 
 def get_args():

--- a/minifier.py
+++ b/minifier.py
@@ -138,13 +138,16 @@ def minify_source_file(args, filename):
         if args.names is True:
             print("File {}:".format(source_file))
         lines = f.readlines()
-        if args.keep_newline is False:
-            # Keep preprocessor lines (starting with #)
-            lines = map(lambda x: x.replace(args.crlf, '') if not x.startswith('#') else x, lines)
+
         lines = map(lambda x: x.replace('\t', ' '), lines)
         # erase leading and trailing whitespace but do it BEFORE processing spaced ops!
         # and specify only spaces so it doesn't strip newlines
         lines = map(lambda x: x.strip(' '), lines)
+
+        if args.keep_newline is False:
+            # Keep preprocessor lines (starting with #)
+            lines = map(lambda x: x.replace(args.crlf, '') if not x.startswith('#') else x, lines)
+
         # for each operator: remove space on each side of the op, on every line.
         # Escape ops that could be regex control characters.
         for op in OPS:


### PR DESCRIPTION
fixes #3
Macros similar to the following should be wrapped now right:
```main() {
  #define ONE 1  
  #define TWO 2
}
```
This solution is not perfect (the secound loop is only needed due to a bug in the first but it works fine anyway.
