### PR TITLE
no empty newlines before preprocessor directives

### DIFF
--- a/minifier.py
+++ b/minifier.py
@@ -137,7 +137,8 @@ def reinsert_preprocessor_newlines(lines):
     for idx, line in enumerate(lines):
         if is_preprocessor_directive(line) or (
          idx != len(lines)-1 and is_preprocessor_directive(lines[idx+1])):
-            lines[idx] = lines[idx] + '\n'
+            if not lines[idx] == '':
+                lines[idx] = lines[idx] + '\n'
     return lines
 
 


### PR DESCRIPTION
Fixes issue #10
Usually a newline character is inserted at the end of the line before a
preprocessor directive. However this behaviour is counterproductive if that
line is empty.

Lines are represented as elements of an array. Inserting a newline character in
a (otherwise empty) array element would add an unneccesary newline as a final
result.